### PR TITLE
Remove .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-erlang 21.3.8
-elixir 1.9.4-otp-21


### PR DESCRIPTION
It's woefully out-of-date. Also, this library should work with a variety of Elixir and Erlang versions, so specifying specific ones doesn't quite make sense.