### PR TITLE
Modify Redbird to more gracefully handle Redix Connection Errors

### DIFF
--- a/lib/redbird/plug/session/redis.ex
+++ b/lib/redbird/plug/session/redis.ex
@@ -79,7 +79,7 @@ defmodule Redbird.RedisError do
   @base_message "Redbird was unable to store the session in redis."
 
   def raise(error: error, key: key) do
-    message = "#{@base_message} Redis Error: #{error} key: #{key}"
+    message = "#{@base_message} Redis Error: #{inspect(error)} key: #{key}"
     raise __MODULE__, message
   end
 

--- a/test/redbird_test.exs
+++ b/test/redbird_test.exs
@@ -115,6 +115,20 @@ defmodule RedbirdTest do
                      end
       end
     end
+
+    test "it throws an exception properly when failure is of Redix.ConnectionError type" do
+      with_mock Redbird.Redis, setex: fn _ -> %Redix.ConnectionError{reason: "something"} end do
+        assert_raise Redbird.RedisError,
+                     ~r/Redbird was unable to store the session in redis. Redis Error: %Redix.ConnectionError{reason: \"something\"}/,
+                     fn ->
+                       :get
+                       |> conn("/")
+                       |> sign_conn()
+                       |> put_session(:foo, "bar")
+                       |> send_resp(200, "")
+                     end
+      end
+    end
   end
 
   describe "delete" do


### PR DESCRIPTION
# Problem
Context: https://appsignal.com/joydrive-1/sites/6052d15c14ad662e6b4e414f/exceptions/incidents/156

An [AppSignal Incident](https://appsignal.com/joydrive-1/sites/6052d15c14ad662e6b4e414f/exceptions/incidents/156) made it evident that Redbird lacked sufficient handling for `%RedixConnectionError{}` responses and was causing APM incidents to be raised.

# Solution

This branch introduces changes that allow more graceful handling of these connection errors and will be accurately reflected in our APM.

Co-authored-by: JohnDoneth <doneth7@gmail.com>