### PR TITLE
Allow returning nil for worker spec for adapters that don't need to spawn anything directly

### DIFF
--- a/lib/redbird.ex
+++ b/lib/redbird.ex
@@ -17,9 +17,11 @@ defmodule Redbird do
       )
     end
 
-    children = [
-      {redis_adapter, redis_adapter_options}
-    ]
+    children =
+      case redis_adapter.worker_spec(redis_adapter_options) do
+        nil -> []
+        worker_spec -> [worker_spec]
+      end
 
     opts = [strategy: :one_for_one, name: Redbird.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/redbird/adapter/behaviour.ex
+++ b/lib/redbird/adapter/behaviour.ex
@@ -1,7 +1,7 @@
 defmodule Redbird.Adapter.Behaviour do
   @type command :: [String.Chars.t()]
 
-  @callback start_link(any()) :: {:ok, pid()} | :ignore | {:error, term()}
+  @callback worker_spec(keyword()) :: Supervisor.child_spec() | nil
 
   @callback noreply_command(command(), keyword()) :: {:ok, any()} | {:error, any()}
 

--- a/lib/redbird/adapter/redix.ex
+++ b/lib/redbird/adapter/redix.ex
@@ -2,14 +2,14 @@ if Code.ensure_loaded?(Redix) do
   defmodule Redbird.Adapter.Redix do
     @behaviour Redbird.Adapter.Behaviour
 
-    def child_spec(args) do
+    @impl true
+    def worker_spec(opts) do
       %{
         id: __MODULE__,
-        start: {__MODULE__, :start_link, [args]}
+        start: {__MODULE__, :start_link, [opts]}
       }
     end
 
-    @impl true
     def start_link(opts) do
       Redix.start_link(opts ++ [name: __MODULE__])
     end

--- a/test/adapter_test.exs
+++ b/test/adapter_test.exs
@@ -1,0 +1,26 @@
+defmodule AdapterTest do
+  use Redbird.ConnCase
+
+  test "allows a redis adapter where the adapter does not spawn anything / where worker_spec returns nil" do
+    defmodule TestAdapter do
+      @behaviour Redbird.Adapter.Behaviour
+
+      @impl true
+      def worker_spec(_opts) do
+        nil
+      end
+
+      @impl true
+      def noreply_command(_command, _options \\ []), do: raise("Not implemented")
+
+      @impl true
+      def command(_command, _options \\ []), do: raise("Not implemented")
+    end
+
+    Application.stop(:redbird)
+
+    Application.put_env(:redbird, :redis_adapter, TestAdapter)
+
+    :ok = Application.start(:redbird)
+  end
+end


### PR DESCRIPTION
For adapters that don't need to spawn a Redis connection since they might already be using a pool of connections managed and spawned elsewhere.