### PR TITLE
Add the session expiration datetime to each session

### DIFF
--- a/lib/redbird/config.ex
+++ b/lib/redbird/config.ex
@@ -1,9 +1,10 @@
 defmodule Redbird.Config do
   def redis_adapter do
-    adapter = case Application.get_env(:redbird, :redis_adapter) do
-      {module, _options} -> module
-      module -> module
-    end
+    adapter =
+      case Application.get_env(:redbird, :redis_adapter) do
+        {module, _options} -> module
+        module -> module
+      end
 
     adapter || Redbird.Adapter.Redix
   end


### PR DESCRIPTION
Adds the session expiration as a ISO8601 timestamp in the session itself under the `session_expiration` key that can be accessed using `get_session(conn, :session_expiration)`.